### PR TITLE
Feature/owner only

### DIFF
--- a/checks.py
+++ b/checks.py
@@ -1,8 +1,8 @@
 import xenon_worker as wkr
-from enum import Enum
+from enum import IntEnum
 
 
-class StaffLevel(Enum):
+class StaffLevel(IntEnum):
     NONE = -1
     MOD = 0
     ADMIN = 1
@@ -25,6 +25,45 @@ def is_staff(level=StaffLevel.MOD):
                 raise NotStaff(current=StaffLevel(staff["level"]), required=level)
 
             return True
+
+        return wkr.Check(check, callback)
+
+    return predicate
+
+
+class PermissionLevels(IntEnum):
+    ADMIN_ONY = 0
+    DESTRUCTIVE_OWNER = 1
+    OWNER_ONLY = 2
+
+
+def has_permissions_level(destructive=False):
+    def predicate(callback):
+        async def check(ctx, *args, **kwargs):
+            settings = await ctx.bot.db.guilds.find_one({"_id": ctx.guild_id})
+            if settings is None or "permissions_level" not in settings:
+                required = PermissionLevels.DESTRUCTIVE_OWNER
+
+            else:
+                required = PermissionLevels(settings["permissions_level"])
+
+            if required == PermissionLevels.OWNER_ONLY:
+                try:
+                    return await wkr.is_owner(callback)
+                except wkr.NotOwner:
+                    raise
+
+            elif required == PermissionLevels.DESTRUCTIVE_OWNER and destructive:
+                try:
+                    return await wkr.is_owner(callback)
+                except wkr.NotOwner:
+                    raise
+
+            else:
+                try:
+                    return await wkr.has_permissions(administrator=True)(callback)
+                except wkr.MissingPermissions:
+                    raise
 
         return wkr.Check(check, callback)
 

--- a/checks.py
+++ b/checks.py
@@ -49,19 +49,19 @@ def has_permissions_level(destructive=False):
 
             if required == PermissionLevels.OWNER_ONLY:
                 try:
-                    return await wkr.is_owner(callback)
+                    return await wkr.is_owner(callback).run(ctx, *args, **kwargs)
                 except wkr.NotOwner:
                     raise
 
             elif required == PermissionLevels.DESTRUCTIVE_OWNER and destructive:
                 try:
-                    return await wkr.is_owner(callback)
+                    return await wkr.is_owner(callback).run(ctx, *args, **kwargs)
                 except wkr.NotOwner:
                     raise
 
             else:
                 try:
-                    return await wkr.has_permissions(administrator=True)(callback)
+                    return await wkr.has_permissions(administrator=True)(callback).run(ctx, *args, **kwargs)
                 except wkr.MissingPermissions:
                     raise
 

--- a/checks.py
+++ b/checks.py
@@ -51,13 +51,17 @@ def has_permissions_level(destructive=False):
                 try:
                     return await wkr.is_owner(callback).run(ctx, *args, **kwargs)
                 except wkr.NotOwner:
-                    raise
+                    raise ctx.f.ERROR("Only the **server owner** can use this command.\n"
+                                      f"The server owner can change this using "
+                                      f"`{ctx.bot.prefix}help settings permissions`.")
 
             elif required == PermissionLevels.DESTRUCTIVE_OWNER and destructive:
                 try:
                     return await wkr.is_owner(callback).run(ctx, *args, **kwargs)
                 except wkr.NotOwner:
-                    raise
+                    raise ctx.f.ERROR("Only the **server owner** can use this command.\n"
+                                      f"The server owner can change this using "
+                                      f"`{ctx.bot.prefix}help settings permissions`.")
 
             else:
                 try:

--- a/modules/__init__.py
+++ b/modules/__init__.py
@@ -7,6 +7,7 @@ from .redis import Redis
 from .blacklist import Blacklist
 from .premium import Premium
 from .audit_logs import AuditLogs
+from .settings import Settings
 
 
-to_load = (Help, Admin, Backups, Basics, Templates, Redis, Blacklist, Premium, AuditLogs)
+to_load = (Help, Admin, Backups, Basics, Templates, Redis, Blacklist, Premium, AuditLogs, Settings)

--- a/modules/backups.py
+++ b/modules/backups.py
@@ -71,7 +71,7 @@ class Backups(wkr.Module):
 
     @backup.command(aliases=("c",))
     @wkr.guild_only
-    @wkr.has_permissions(administrator=True)
+    @checks.has_permissions_level()
     @wkr.bot_has_permissions(administrator=True)
     @wkr.cooldown(1, 10, bucket=wkr.CooldownType.GUILD)
     async def create(self, ctx):
@@ -123,7 +123,7 @@ class Backups(wkr.Module):
 
     @backup.command(aliases=("l",))
     @wkr.guild_only
-    @wkr.has_permissions(administrator=True)
+    @checks.has_permissions_level(destructive=True)
     @wkr.bot_has_permissions(administrator=True)
     @wkr.cooldown(1, 60, bucket=wkr.CooldownType.GUILD)
     async def load(self, ctx, backup_id, *options):
@@ -366,7 +366,7 @@ class Backups(wkr.Module):
 
     @backup.command(aliases=("iv",))
     @wkr.guild_only
-    @wkr.has_permissions(administrator=True)
+    @checks.has_permissions_level()
     @wkr.bot_has_permissions(administrator=True)
     @wkr.cooldown(1, 10, bucket=wkr.CooldownType.GUILD)
     async def interval(self, ctx, *interval):

--- a/modules/backups.py
+++ b/modules/backups.py
@@ -70,7 +70,7 @@ class Backups(wkr.Module):
         raise ctx.f.SUCCESS(f"Successfully transferred backup.")
 
     @backup.command(aliases=("c",))
-    @wkr.guild_onl
+    @wkr.guild_only
     @checks.has_permissions_level()
     @wkr.bot_has_permissions(ban_members=True)
     @wkr.cooldown(1, 10, bucket=wkr.CooldownType.GUILD)

--- a/modules/settings.py
+++ b/modules/settings.py
@@ -1,0 +1,104 @@
+import xenon_worker as wkr
+from datetime import datetime, timedelta
+
+import checks
+
+
+class Settings(wkr.Module):
+    @wkr.Module.task(hours=1)
+    async def audit_log_retention(self):
+        await self.bot.db.audit_logs.delete_many({
+            "timestamp": {
+                "$lte": datetime.utcnow() - timedelta(days=365)
+            }
+        })
+
+    @wkr.Module.command(aliases=("set",))
+    @wkr.guild_only
+    @wkr.has_permissions(administrator=True)
+    @wkr.cooldown(1, 5, bucket=wkr.CooldownType.GUILD)
+    async def settings(self, ctx):
+        """
+        Change Xenons settings for your server
+        """
+        await ctx.invoke("help settings")
+
+    @wkr.Module.command(aliases=("set",))
+    @wkr.guild_only
+    @wkr.is_owner
+    @wkr.cooldown(1, 30, bucket=wkr.CooldownType.GUILD)
+    async def reset(self, ctx):
+        """
+        Reset the server settings to the default values
+
+
+        __Examples__
+
+        ```{b.prefix}settings reset```
+        """
+        await ctx.db.guilds.delete_one({"_id": ctx.guild_id})
+        raise ctx.f.SUCCESS(f"Successfully **reset settings** to the default values.")
+
+    @settings.command(aliases=("perms", "permission"))
+    @wkr.guild_only
+    @wkr.is_owner
+    @wkr.cooldown(1, 5, bucket=wkr.CooldownType.GUILD)
+    async def permissions(self, ctx, *, level=None):
+        """
+        Set the permissions level for your server
+
+        This affects the following commands:
+        `backup load`, `backup create`, `template load`, `backup interval`
+
+        __Levels__
+
+        Server admins can create backups, enable the backup interval and load a template or backup:
+        **Be careful with this!**
+        ```{b.prefix}settings permissions admins```
+
+        Admins can create backups and enable the backup interval but only owners can load backups or templates
+        ```{b.prefix}settings permissions destructive owner```
+
+        Only owners can create backups, enable the backup interval and load a template or backup
+        ```{b.prefix}settings permissions owner```
+        """
+        if level is None:
+            settings = await ctx.bot.db.guilds.find_one({"_id": ctx.guild_id})
+            if settings is None or "permissions_level" not in settings:
+                level = checks.PermissionLevels.DESTRUCTIVE_OWNER
+
+            else:
+                level = checks.PermissionLevels(settings["permissions_level"])
+
+        else:
+            level = level.replace("-", " ").replace("_", " ")
+            if level == "admins":
+                conf_level = checks.PermissionLevels.ADMIN_ONY
+                await ctx.f.SUCCESS("**Changed the permissions level** for this server.\n"
+                                    "**Server admins can now create backups, enable the backup interval and "
+                                    "load a template or backup**\n"
+                                    f"Use `{ctx.bot.prefix}help settings permissions` to get more info.")
+
+            elif level == "destructive owner":
+                conf_level = checks.PermissionLevels.DESTRUCTIVE_OWNER
+                await ctx.f.SUCCESS("**Changed the permissions level** for this server.\n"
+                                    "**Server admins can now create backups and enable the backup interval** but "
+                                    "**only the server owner can load backups or templates**.\n"
+                                    f"Use `{ctx.bot.prefix}help settings permissions` to get more info.")
+
+            elif level == "owner":
+                conf_level = checks.PermissionLevels.OWNER_ONLY
+                await ctx.f.SUCCESS("**Changed the permissions level** for this server.\n"
+                                    "**Only the server owner can now use any of the relevant commands**.\n"
+                                    f"Use `{ctx.bot.prefix}help settings permissions` to get more info.")
+
+            else:
+                await ctx.f_send(f"`{level}` is **not** a **valid** permissions level.", f=ctx.f.ERROR)
+                await ctx.invoke("help settings permissions")
+                return
+
+            await ctx.db.update_one(
+                {"_id": ctx.guild_id},
+                {"$set": {"_id": ctx.guild_id, "permissions_level": conf_level}},
+                upsert=True
+            )

--- a/modules/settings.py
+++ b/modules/settings.py
@@ -3,6 +3,14 @@ from datetime import datetime, timedelta
 
 import checks
 
+PERMISSION_DESCRIPTIONS = {
+    checks.PermissionLevels.ADMIN_ONY: "Server admins can create backups, enable the backup interval and "
+                                       "load a template or backup",
+    checks.PermissionLevels.DESTRUCTIVE_OWNER: "Server admins can create backups and enable the backup interval "
+                                               "but only the server owner can load backups or templates",
+    checks.PermissionLevels.OWNER_ONLY: "Only the server owner can use any of the relevant commands"
+}
+
 
 class Settings(wkr.Module):
     @wkr.Module.task(hours=1)
@@ -15,7 +23,7 @@ class Settings(wkr.Module):
 
     @wkr.Module.command(aliases=("set",))
     @wkr.guild_only
-    @wkr.has_permissions(administrator=True)
+    @wkr.is_owner
     @wkr.cooldown(1, 5, bucket=wkr.CooldownType.GUILD)
     async def settings(self, ctx):
         """
@@ -23,9 +31,7 @@ class Settings(wkr.Module):
         """
         await ctx.invoke("help settings")
 
-    @wkr.Module.command(aliases=("set",))
-    @wkr.guild_only
-    @wkr.is_owner
+    @settings.command()
     @wkr.cooldown(1, 30, bucket=wkr.CooldownType.GUILD)
     async def reset(self, ctx):
         """
@@ -36,12 +42,10 @@ class Settings(wkr.Module):
 
         ```{b.prefix}settings reset```
         """
-        await ctx.db.guilds.delete_one({"_id": ctx.guild_id})
+        await ctx.bot.db.guilds.delete_one({"_id": ctx.guild_id})
         raise ctx.f.SUCCESS(f"Successfully **reset settings** to the default values.")
 
     @settings.command(aliases=("perms", "permission"))
-    @wkr.guild_only
-    @wkr.is_owner
     @wkr.cooldown(1, 5, bucket=wkr.CooldownType.GUILD)
     async def permissions(self, ctx, *, level=None):
         """
@@ -52,8 +56,7 @@ class Settings(wkr.Module):
 
         __Levels__
 
-        Server admins can create backups, enable the backup interval and load a template or backup:
-        **Be careful with this!**
+        Server admins can create backups, enable the backup interval and load a template or backup (**Be careful with this!**):
         ```{b.prefix}settings permissions admins```
 
         Admins can create backups and enable the backup interval but only owners can load backups or templates
@@ -70,34 +73,39 @@ class Settings(wkr.Module):
             else:
                 level = checks.PermissionLevels(settings["permissions_level"])
 
+            raise ctx.f.INFO(f"__Your current permission settings are:__\n"
+                             f"{PERMISSION_DESCRIPTIONS[level]}\n\n"
+                             f"*Use `{ctx.bot.prefix}help settings permissions` to get more info.*")
+
         else:
             level = level.replace("-", " ").replace("_", " ")
             if level == "admins":
                 conf_level = checks.PermissionLevels.ADMIN_ONY
-                await ctx.f.SUCCESS("**Changed the permissions level** for this server.\n"
-                                    "**Server admins can now create backups, enable the backup interval and "
-                                    "load a template or backup**\n"
-                                    f"Use `{ctx.bot.prefix}help settings permissions` to get more info.")
+                await ctx.f_send("__Changed the permissions level for this server to:__\n"
+                                 f"**{PERMISSION_DESCRIPTIONS[conf_level]}**\n\n"
+                                 f"*Use `{ctx.bot.prefix}help settings permissions` to get more info.*",
+                                 f=ctx.f.SUCCESS)
 
             elif level == "destructive owner":
                 conf_level = checks.PermissionLevels.DESTRUCTIVE_OWNER
-                await ctx.f.SUCCESS("**Changed the permissions level** for this server.\n"
-                                    "**Server admins can now create backups and enable the backup interval** but "
-                                    "**only the server owner can load backups or templates**.\n"
-                                    f"Use `{ctx.bot.prefix}help settings permissions` to get more info.")
+                await ctx.f_send("__Changed the permissions level for this server to:__\n"
+                                 f"**{PERMISSION_DESCRIPTIONS[conf_level]}**.\n\n"
+                                 f"*Use `{ctx.bot.prefix}help settings permissions` to get more info.*",
+                                 f=ctx.f.SUCCESS)
 
             elif level == "owner":
                 conf_level = checks.PermissionLevels.OWNER_ONLY
-                await ctx.f.SUCCESS("**Changed the permissions level** for this server.\n"
-                                    "**Only the server owner can now use any of the relevant commands**.\n"
-                                    f"Use `{ctx.bot.prefix}help settings permissions` to get more info.")
+                await ctx.f_send("__Changed the permissions level for this server to:__\n"
+                                 f"**{PERMISSION_DESCRIPTIONS[conf_level]}**.\n\n"
+                                 f"*Use `{ctx.bot.prefix}help settings permissions` to get more info.*",
+                                 f=ctx.f.SUCCESS)
 
             else:
                 await ctx.f_send(f"`{level}` is **not** a **valid** permissions level.", f=ctx.f.ERROR)
                 await ctx.invoke("help settings permissions")
                 return
 
-            await ctx.db.update_one(
+            await ctx.bot.db.guilds.update_one(
                 {"_id": ctx.guild_id},
                 {"$set": {"_id": ctx.guild_id, "permissions_level": conf_level}},
                 upsert=True

--- a/modules/settings.py
+++ b/modules/settings.py
@@ -95,6 +95,7 @@ class Settings(wkr.Module):
 
             elif level == "owner":
                 conf_level = checks.PermissionLevels.OWNER_ONLY
+                await ctx.bot.db.intervals.delete_many({"guild": ctx.guild_id, "user": {"$ne": ctx.author.id}})
                 await ctx.f_send("__Changed the permissions level for this server to:__\n"
                                  f"**{PERMISSION_DESCRIPTIONS[conf_level]}**.\n\n"
                                  f"*Use `{ctx.bot.prefix}help settings permissions` to get more info.*",

--- a/modules/templates.py
+++ b/modules/templates.py
@@ -6,6 +6,7 @@ import pymongo.errors
 from os import environ as env
 import msgpack
 
+import checks
 from backups import BackupLoader
 
 
@@ -117,7 +118,7 @@ class Templates(wkr.Module):
 
     @template.command(aliases=("l",))
     @wkr.guild_only
-    @wkr.has_permissions(administrator=True)
+    @checks.has_permissions_level(destructive=True)
     @wkr.bot_has_permissions(administrator=True)
     @wkr.cooldown(1, 60, bucket=wkr.CooldownType.GUILD)
     async def load(self, ctx, name, *options):


### PR DESCRIPTION
There are now three different permission levels that can be set per guild. 
- Admin Only (basically how it works atm)
- Destructive Owner (Only owners can load backups or templates) <-- enabled by default
- Owner Only (All relevant commands can only be used by the server owner)

Enabling owner only mode also deletes all active backup intervals for everyone beside the owner.

The settings can be changed using the new `x!settings` command. 

Closes #5 