### PR TITLE
Feature/role sync

### DIFF
--- a/modules/sync.py
+++ b/modules/sync.py
@@ -384,6 +384,10 @@ class Sync(wkr.Module):
             raise ctx.f.ERROR(f"`{direction}` is **not a valid sync direction**.\n"
                               f"Choose from `{', '.join([l.name.lower() for l in SyncDirection])}`.")
 
+        if direction == SyncDirection.BOTH:
+            raise ctx.f.ERROR("Syncing role assignments in **both directions can cause bugs**."
+                              "This will eventually be fixed at some point.")
+
         source = await role_a(ctx)
         source_guild = await ctx.client.get_full_guild(source.guild_id)
         await self._check_admin_on(source_guild, ctx)
@@ -406,15 +410,15 @@ class Sync(wkr.Module):
                 })
             except pymongo.errors.DuplicateKeyError:
                 await ctx.f_send(
-                    f"Sync from {source_role.name} (`{source_role.id}`) to {target_role.name} (`{target_role.id}`) "
+                    f"Sync from `{source_role.name}` (`{source_role.id}`) to `{target_role.name}` (`{target_role.id}`) "
                     f"**already exists**.",
                     f=ctx.f.INFO
                 )
 
             else:
                 await ctx.f_send(
-                    f"Successfully **created sync** from {source_role.name} (`{source_role.id}`) to "
-                    f"{target_role.name} (`{target_role.id}`)with the id `{sync_id}`",
+                    f"Successfully **created sync** from `{source_role.name}` (`{source_role.id}`) to "
+                    f"`{target_role.name}` (`{target_role.id}`) with the id `{sync_id}`",
                     f=ctx.f.SUCCESS
                 )
                 await ctx.bot.create_audit_log(

--- a/modules/sync.py
+++ b/modules/sync.py
@@ -348,7 +348,7 @@ class Sync(wkr.Module):
     @wkr.guild_only
     @checks.has_permissions_level(destructive=True)
     @wkr.bot_has_permissions(administrator=True)
-    @checks.is_premium()
+    @checks.is_premium(checks.PremiumLevel.THREE)
     async def role(self, ctx, role_a: wkr.RoleConverter, direction, role_b: wkr.RoleConverter):
         """
         Sync role assignments for one role to another role

--- a/modules/sync.py
+++ b/modules/sync.py
@@ -447,32 +447,32 @@ class Sync(wkr.Module):
             added_roles = [r for r in data["roles"] if r not in prev_roles]
             removed_roles = [r for r in prev_roles if r not in data["roles"]]
 
-            for role_id in added_roles:
-                syncs = self.bot.db.premium.syncs.find({"source": role_id, "type": SyncType.ROLE})
-                async for sync in syncs:
-                    await self.client.add_role(
-                        wkr.Snowflake(sync["target_guild"]),
-                        wkr.Snowflake(data["user"]["id"]),
-                        wkr.Snowflake(sync["target"]),
-                        reason=f"Role sync {sync['_id']}"
-                    )
-
-            for role_id in removed_roles:
-                syncs = self.bot.db.premium.syncs.find({"source": role_id, "type": SyncType.ROLE})
-                async for sync in syncs:
-                    await self.client.remove_role(
-                        wkr.Snowflake(sync["target_guild"]),
-                        wkr.Snowflake(data["user"]["id"]),
-                        wkr.Snowflake(sync["target"]),
-                        reason=f"Role sync {sync['_id']}"
-                    )
-
         finally:
             await self.client.redis.hset(
                 f"role_syncs:{data['guild_id']}",
                 data['user']['id'],
                 msgpack.packb(data["roles"])
             )
+
+        for role_id in added_roles:
+            syncs = self.bot.db.premium.syncs.find({"source": role_id, "type": SyncType.ROLE})
+            async for sync in syncs:
+                await self.client.add_role(
+                    wkr.Snowflake(sync["target_guild"]),
+                    wkr.Snowflake(data["user"]["id"]),
+                    wkr.Snowflake(sync["target"]),
+                    reason=f"Role sync {sync['_id']}"
+                )
+
+        for role_id in removed_roles:
+            syncs = self.bot.db.premium.syncs.find({"source": role_id, "type": SyncType.ROLE})
+            async for sync in syncs:
+                await self.client.remove_role(
+                    wkr.Snowflake(sync["target_guild"]),
+                    wkr.Snowflake(data["user"]["id"]),
+                    wkr.Snowflake(sync["target"]),
+                    reason=f"Role sync {sync['_id']}"
+                )
 
     @wkr.Module.listener()
     async def on_guild_member_remove(self, _, data):

--- a/modules/sync.py
+++ b/modules/sync.py
@@ -361,11 +361,13 @@ class Sync(wkr.Module):
         Sync role assignments for one role to another role
         The roles can be on different servers
 
+        **Creating assignment loops with this is highly discouraged. This also applies to the `both` direction.**
+
 
         __Arguments__
 
         **source_role**: The id of the first role (role A)
-        **direction**: `from`, `to` or `both`
+        **direction**: `from` or `to`
         **target**: The id of the second role (role B)
 
 


### PR DESCRIPTION
Add the ability to sync role assignments from one role to another. For example: Role A gets added to Member X, the bot also adds Role B to Member X. This works across servers.
Role sync will only be available to Premium 3 users for now, as I'm not sure how much performance it will take.

A role sync in both directions is currently pretty buggy, because the partial role cache is not able to update that fast. A temporary lock for each member might help.

This is not ready to be merged, as there are still some issues to be fixed.
This also requires the privileged member intent, which I still don't got. (I have to provide discord with a video of the feature, which I didn't do yet)

Closes #25 