### PR TITLE
Feature/msg sync exta events

### DIFF
--- a/modules/sync.py
+++ b/modules/sync.py
@@ -171,7 +171,12 @@ class Sync(wkr.Module):
             raise ctx.f.ERROR(f"`{direction}` is **not a valid sync direction**.\n"
                               f"Choose from `{', '.join([l.name.lower() for l in SyncDirection])}`.")
 
-        extra_events = Options(**utils.backup_options(extra_events))
+        options = Options(
+            delete=True,
+            edit=True,
+            pin=True
+        )
+        options.update(**utils.backup_options(extra_events))
 
         channel = await target(ctx)
         guild = await self.client.get_full_guild(channel.guild_id)
@@ -189,9 +194,9 @@ class Sync(wkr.Module):
                     "source": source_id,
                     "webhook": webh.to_dict(),
                     "events": {
-                        "delete": extra_events.delete,
-                        "edit": extra_events.edit,
-                        "pin": extra_events.pin
+                        "delete": options.delete,
+                        "edit": options.edit,
+                        "pin": options.pin
                     },
                     "uses": 0
                 })

--- a/modules/sync.py
+++ b/modules/sync.py
@@ -261,7 +261,7 @@ class Sync(wkr.Module):
                 )
                 await self.bot.db.premium.syncs.update_one(sync, {
                     "$inc": {"uses": 1},
-                    "$push": {"ids": {"$each": [[msg.id, new_msg.id]], "$slice": -10}}
+                    "$push": {"ids": {"$each": [[msg.id, new_msg.id]], "$slice": -1000}}
                 })
             except wkr.NotFound:
                 await self.bot.db.syncs.delete_one({"_id": sync["_id"]})

--- a/modules/sync.py
+++ b/modules/sync.py
@@ -65,6 +65,9 @@ class Sync(wkr.Module):
         )
 
         await self.bot.subscribe("*.message_create", shared=True)
+        await self.bot.subscribe("*.message_update", shared=True)
+        await self.bot.subscribe("*.message_delete", shared=True)
+
         await self.bot.subscribe("*.guild_ban_add", shared=True)
         await self.bot.subscribe("*.guild_ban_remove", shared=True)
 
@@ -152,7 +155,7 @@ class Sync(wkr.Module):
 
         **direction**: `from`, `to` or `both`
         **target**: The target channel (mention or id)
-        **extra_events**: Option list of extra events (delete, edit, pin) (similar to the backup load command)
+        **extra_events**: Option list of extra events (delete, edit) (similar to the backup load command)
 
 
         __Examples__
@@ -173,8 +176,7 @@ class Sync(wkr.Module):
 
         options = Options(
             delete=True,
-            edit=True,
-            pin=True
+            edit=True
         )
         options.update(**utils.backup_options(extra_events))
 
@@ -195,8 +197,7 @@ class Sync(wkr.Module):
                     "webhook": webh.to_dict(),
                     "events": {
                         "delete": options.delete,
-                        "edit": options.edit,
-                        "pin": options.pin
+                        "edit": options.edit
                     },
                     "uses": 0
                 })
@@ -260,7 +261,7 @@ class Sync(wkr.Module):
                 )
                 await self.bot.db.premium.syncs.update_one(sync, {
                     "$inc": {"uses": 1},
-                    "$push": {"ids": {"$each": [[msg.id, new_msg.id]], "$slice": -1000}}
+                    "$push": {"ids": {"$each": [[msg.id, new_msg.id]], "$slice": -10}}
                 })
             except wkr.NotFound:
                 await self.bot.db.syncs.delete_one({"_id": sync["_id"]})
@@ -329,10 +330,6 @@ class Sync(wkr.Module):
 
             except Exception:
                 traceback.print_exc()
-
-    @wkr.Module.listener()
-    async def on_channel_pins_update(self, _, data):
-        pass
 
     @sync.command()
     @wkr.guild_only

--- a/modules/sync.py
+++ b/modules/sync.py
@@ -271,13 +271,10 @@ class Sync(wkr.Module):
 
     @wkr.Module.listener()
     async def on_message_update(self, _, data):
-        msg = wkr.Message(data)
-        if msg.webhook_id:
+        if data.get("webhook_id"):
             return
 
-        files = await self._load_attachments(msg)
-
-        syncs = self.bot.db.premium.syncs.find({"source": msg.channel_id, "type": SyncType.MESSAGES})
+        syncs = self.bot.db.premium.syncs.find({"source": data["channel_id"], "type": SyncType.MESSAGES})
         async for sync in syncs:
             if not sync.get("events", {}).get("edit"):
                 continue
@@ -295,10 +292,7 @@ class Sync(wkr.Module):
                 await self.client.execute_webhook(
                     webh,
                     message_id=new_msg_id,
-                    username=msg.author.name,
-                    avatar_url=msg.author.avatar_url,
-                    files=files,
-                    **msg.to_dict(),
+                    **data,
                     allowed_mentions={"parse": []},
                 )
             except wkr.NotFound:


### PR DESCRIPTION
`message_update` and `message_delete` events can now be synced. This works for the last 1k (per sync) messages that have been transferred. `channel_pins_update` is not going to be synced due to technical difficulties.
Syncing edits and deletes can be disabled using an options array: `x?sync messages from #general !edit !delete`
Existing syncs must be recreated to take advantage of this.